### PR TITLE
Use a fixed version instead of the unstable master.

### DIFF
--- a/recipes-devtools/python/python3-json-rpc.bb
+++ b/recipes-devtools/python/python3-json-rpc.bb
@@ -1,14 +1,14 @@
 SUMMARY = "Python json rpc recipe"
 HOMEPAGE = "https://pypi.org/project/json-rpc/"
+PV = "1.13.0"
 SECTION = "devel/python"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SRC_URI = "git://github.com/pavlov99/json-rpc;protocol=https;tag=${PV}"
+SRC_URI[md5sum] = "489a8d3943821cc2069af64ab53a79c4"
+SRC_URI[sha256sum] = "12e4ee807466d80c779313ca3f3f0ecf2bf3e66af9e426ee0d7e4d1190effadb"
 
-SRC_URI = "https://github.com/pavlov99/json-rpc/archive/master.zip"
-SRC_URI[md5sum] = "f705d5c2b45265c9a889a28e581f0df0"
-SRC_URI[sha256sum] = "adc0107f3c389660efa6441bfb0c987eb675edb4533de02fd93091429aab372d"
-
-S = "${WORKDIR}/json-rpc-master"
+S = "${WORKDIR}/git"
 
 inherit setuptools3
 


### PR DESCRIPTION
In the meantime the build was broken.

In addition there was a warning:
>     * WARNING: python3-json-rpc-1.0-r0 do_package_qa: QA Issue: python3-json-rpc: SRC_URI uses unstable GitHub/GitLab archives, convert recipe to use git protocol [src-uri-bad]

This change proposes to use a fixed version, instead of master to avoid unstable builds.

if you really need master, this PR can be rejected, but then the checksums have to be updated, to make the build again